### PR TITLE
Default UI to blueocean

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -105,7 +105,11 @@ jenkins:
     Memory: "256Mi"
   # Set min/max heap here if needed with:
   # JavaOpts: "-Xms512m -Xmx512m"
-    JavaOpts: "-Dhudson.slaves.NodeProvisioner.initialDelay=0 -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85"
+    JavaOpts: >
+      -Dhudson.slaves.NodeProvisioner.initialDelay=0
+      -Dhudson.slaves.NodeProvisioner.MARGIN=50
+      -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85
+      -Djenkins.displayurl.provider=org.jenkinsci.plugins.blueoceandisplayurl.BlueOceanDisplayURLImpl
   # JenkinsOpts: ""
   # JenkinsUriPrefix: "/jenkins"
     ServicePort: 8080


### PR DESCRIPTION
This commit is a simple change that switches the displayprovider to use blueocean as a redirect instead of the classic UI. This provides a more up-to-date and streamlined view for viewing pipelines.

It would be nice to configure this - but talking to @rawlingsj and @jstrachan this seemed like a good default. 

In order to run this and see it for yourself - you can edit `~/.jx/cloud-environments/env-gke/myvalues.yaml` to be [this gist](https://gist.github.com/rawlingsj/8cb8929e97053d101fb5f44c4abdf8cc) (shoutout to @rawlingsj for providing this!). Then rerun `jx install` -- this is still a little rough and you might have to address [this issue](https://github.com/jenkins-x/jx/issues/666).

But once done your PR builds should -> blue ocean!