### PR TITLE
Update ChartMuseum image and chart to their latest versions

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -17,8 +17,8 @@ dependencies:
     version: 0.0.1
     repository: file://pipelinecontroller
   - name: chartmuseum
-    version: 0.3.2                                                
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    version: 1.5.0                                                
+    repository: https://kubernetes-charts.storage.googleapis.com
   - name: nexus
     version: 0.0.14
     repository: http://chartmuseum.build.cd.jenkins-x.io

--- a/values.yaml
+++ b/values.yaml
@@ -66,7 +66,7 @@ chartmuseum:
       BASIC_AUTH_USER: admin
       BASIC_AUTH_PASS: admin
   image:
-    tag: v0.2.8
+    tag: v0.7.0
   resources:
     limits:
       cpu: 200m


### PR DESCRIPTION
Noticed that ChartMuseum and its chart are woefully out of date. The chart has graduated from incubation and, among other things, has better support for Google Cloud Storage, which I'm interested in using for chart syncing between multiple clusters.

Not sure if this is the correct way to do an update or if anything else needs to be updated.