### PR TITLE
fix: make jenkins-x-platform more modular and allow service linking

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -13,18 +13,22 @@ dependencies:
   - name: pipelinecontroller
     version: 0.0.1
     repository: file://pipelinecontroller
+    condition: pipelinecontroller.enabled
   - name: chartmuseum
     version: 0.3.2                                                
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: chartmuseum.enabled
   - name: nexus
     version: 0.0.14
     repository: http://chartmuseum.build.cd.jenkins-x.io
+    condition: nexus.enabled
   - name: heapster
     version: 0.2.4
     repository: https://kubernetes-charts.storage.googleapis.com
   - name: monocular
     version: 0.5.1
     repository: http://chartmuseum.build.cd.jenkins-x.io
+    condition: monocular.enabled
   - name: docker-registry
     version: 1.0.1
     repository: https://kubernetes-charts.storage.googleapis.com

--- a/templates/chartmuseum-link-service.yaml
+++ b/templates/chartmuseum-link-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.chartmuseum-service-link.enabled }}
+{{ if .Values.chartmuseumServiceLink.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,5 +10,5 @@ metadata:
     release: jenkins-x
 spec:
   type: ExternalName
-  externalName: {{ .Values.chartmuseum-service-link.externalName }}
+  externalName: {{ .Values.chartmuseumServiceLink.externalName }}
 {{ end }}

--- a/templates/chartmuseum-link-service.yaml
+++ b/templates/chartmuseum-link-service.yaml
@@ -11,3 +11,4 @@ metadata:
 spec:
   type: ExternalName
   externalName: {{ .Values.chartmuseum-service-link.externalName }}
+{{ end }}

--- a/templates/chartmuseum-link-service.yaml
+++ b/templates/chartmuseum-link-service.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.chartmuseum-service-link.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins-x-chartmuseum
+  annotations:
+    fabric8.io/expose: "true"
+  labels:
+    app: chartmuseum
+    release: jenkins-x
+spec:
+  type: ExternalName
+  externalName: {{ .Values.chartmuseum-service-link.externalName }}

--- a/templates/nexus-link-service.yaml
+++ b/templates/nexus-link-service.yaml
@@ -11,3 +11,4 @@ metadata:
 spec:
   type: ExternalName
   externalName: {{ .Values.nexus-service-link.externalName }}
+{{ end }}

--- a/templates/nexus-link-service.yaml
+++ b/templates/nexus-link-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.nexus-service-link.enabled }}
+{{ if .Values.nexusServiceLink.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,5 +10,5 @@ metadata:
     release: jenkins-x
 spec:
   type: ExternalName
-  externalName: {{ .Values.nexus-service-link.externalName }}
+  externalName: {{ .Values.nexusServiceLink.externalName }}
 {{ end }}

--- a/templates/nexus-link-service.yaml
+++ b/templates/nexus-link-service.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.nexus-service-link.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: nexus
+  annotations:
+    fabric8.io/expose: "true"
+  labels:
+    app: nexus
+    release: jenkins-x
+spec:
+  type: ExternalName
+  externalName: {{ .Values.nexus-service-link.externalName }}

--- a/values.yaml
+++ b/values.yaml
@@ -90,6 +90,9 @@ cleanup:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: hook-succeeded
 
+pipelinecontroller:
+  enabled: true
+
 docker-registry:
   service:
     annotations:
@@ -106,12 +109,20 @@ kubernetes-dashboard:
     fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/auth-type: basic\nnginx.ingress.kubernetes.io/auth-secret: jx-basic-auth"
 
 nexus:
+  enabled: true
   service:
     annotations:
       fabric8.io/expose: "true"
       fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
 
+nexus-service-link:
+  enabled: false
+
+  # specify the external name here for where the nexus should point
+  externalName: ""
+
 chartmuseum:
+  enabled: true
   service:
     annotations:
       fabric8.io/expose: "true"
@@ -137,39 +148,47 @@ chartmuseum:
       cpu: 160m
       memory: 128Mi
 
+chartmuseum-service-link:
+  enabled: false
+
+  # specify the external name here for where the chartmuseum should be
+  externalName: ""
+
 monocular:
-    ingress:
-      enabled: false
-    api:
-      livenessProbe:
-        initialDelaySeconds: 360
-      replicaCount: 1
-      service:
-        type: ClusterIP
-        annotations:
-          fabric8.io/expose: "true"
-          fabric8.io/ingress.name: "monocular"
-          fabric8.io/ingress.path: "/api/"
-          fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/rewrite-target: /\nnginx.ingress.kubernetes.io/ingress.class: nginx"
-      config:
-        repos:
-          - name: chartmuseum
-            url: http://jenkins-x-chartmuseum:8080
-            source: https://github.com/jenkins-x/jenkins-x-platfrom
-        cacheRefreshInterval: 30
-        releasesEnabled: false
-    ui:
-      appName: Jenkins X Apps
-      replicaCount: 1
-      service:
-        type: ClusterIP
-        annotations:
-          fabric8.io/expose: "true"
-          fabric8.io/ingress.name: "monocular"
-          fabric8.io/ingress.path: "/"
-    prerender:
-      service:
-        type: ClusterIP
+  enabled: true
+  ingress:
+    enabled: false
+  api:
+    livenessProbe:
+      initialDelaySeconds: 360
+    replicaCount: 1
+    service:
+      type: ClusterIP
+      annotations:
+        fabric8.io/expose: "true"
+        fabric8.io/ingress.name: "monocular"
+        fabric8.io/ingress.path: "/api/"
+        fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/rewrite-target: /\nnginx.ingress.kubernetes.io/ingress.class: nginx"
+    config:
+      repos:
+        - name: chartmuseum
+          url: http://jenkins-x-chartmuseum:8080
+          source: https://github.com/jenkins-x/jenkins-x-platfrom
+      cacheRefreshInterval: 30
+      releasesEnabled: false
+  ui:
+    appName: Jenkins X Apps
+    replicaCount: 1
+    service:
+      type: ClusterIP
+      annotations:
+        fabric8.io/expose: "true"
+        fabric8.io/ingress.name: "monocular"
+        fabric8.io/ingress.path: "/"
+  prerender:
+    service:
+      type: ClusterIP
+
 jenkins:
   # Default values for jenkins.
   # This is a YAML-formatted file.

--- a/values.yaml
+++ b/values.yaml
@@ -115,7 +115,7 @@ nexus:
       fabric8.io/expose: "true"
       fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
 
-nexus-service-link:
+nexusServiceLink:
   enabled: false
 
   # specify the external name here for where the nexus should point
@@ -148,7 +148,7 @@ chartmuseum:
       cpu: 160m
       memory: 128Mi
 
-chartmuseum-service-link:
+chartmuseumServiceLink:
   enabled: false
 
   # specify the external name here for where the chartmuseum should be


### PR DESCRIPTION
lets make it easy to service link to other nexus / chart museum repos
and disable things like monocular and pipelinecontroller