### PR TITLE
Revert "feat: update jenkins image to version 0.0.29"

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -203,7 +203,7 @@ jenkins:
     # Image: "jenkinsci/jenkins"
     # ImageTag: "2.89"
     Image: "jenkinsxio/jenkinsx"
-    ImageTag: "0.0.29"
+    ImageTag: "0.0.28"
     ImagePullPolicy: "IfNotPresent"
     Component: "jenkins-master"
     UseSecurity: true


### PR DESCRIPTION
Issues getting the Jenkins API token

This reverts commit da021dbb7053c28295d037f0356bbfaa3eee80df.