### PR TITLE
fix: allow gc-activities to get deployments

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -102,6 +102,12 @@ gc-activities:
       - get
       - delete
       - list
+    - apiGroups:
+      - ""
+      resources:
+      - deployments
+      verbs:
+      - get
 
 controller-workflow:
   enabled: true


### PR DESCRIPTION
An attempt to at https://github.com/jenkins-x/jx/issues/1705

**This is 100% guessing - I did not test this!**

I believe this change is needed because this Kubernetes command is now run in `jx gc activities`:

https://github.com/jenkins-x/jx/blob/8cd0b7d945addc1957947699360cc4490c712c14/pkg/kube/namespaces.go#L97

```go
	deploy, err := kubeClient.AppsV1beta1().Deployments(ns).Get(DeploymentProwBuild, metav1.GetOptions{})
```