### PR TITLE
gc-activities job fails with missing permissions

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -83,6 +83,12 @@ gc-activities:
       - services
       verbs:
       - get
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - get
   clusterrole:
     enabled: true
     rules:


### PR DESCRIPTION
```
error: deployments.apps "prow-build" is forbidden: User "system:serviceaccount:jx:jenkins-x-gc-activities" cannot get deployments.apps in the namespace "jx"
```