### PR TITLE
Added missing `apps.deployments` apiGroup to gc-activities role

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -102,6 +102,12 @@ gc-activities:
       - get
       - delete
       - list
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - get
 
 controller-workflow:
   enabled: true


### PR DESCRIPTION
Hi,

I've fixed another missing permission problem in gc-activities. This one is required by prow.