### PR TITLE
fix: update jnlp-slave to version 3.26-1

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -545,7 +545,7 @@ jenkins:
     # Image: "jenkinsci/jenkins"
     # ImageTag: "2.89"
     Image: "jenkinsxio/jenkinsx"
-    ImageTag: "0.0.34"
+    ImageTag: "0.0.35"
     ImagePullPolicy: "IfNotPresent"
     Component: "jenkins-master"
     UseSecurity: true

--- a/values.yaml
+++ b/values.yaml
@@ -698,7 +698,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -740,7 +740,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -779,7 +779,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -821,7 +821,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -856,7 +856,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -890,7 +890,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -925,7 +925,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -960,7 +960,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -996,7 +996,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1032,7 +1032,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1066,7 +1066,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1100,7 +1100,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1136,7 +1136,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1172,7 +1172,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1208,7 +1208,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1244,7 +1244,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1279,7 +1279,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.14-1
+            Image: jenkinsci/jnlp-slave:3.26-1
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'

--- a/values.yaml
+++ b/values.yaml
@@ -698,7 +698,7 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -740,7 +740,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -779,7 +780,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -821,7 +823,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -856,7 +859,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -890,7 +894,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -925,7 +930,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -960,7 +966,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -996,7 +1003,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1032,7 +1040,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1066,7 +1075,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1100,7 +1110,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1136,7 +1147,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1172,7 +1184,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1208,7 +1221,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1244,7 +1258,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
@@ -1279,7 +1294,8 @@ jenkins:
         ServiceAccount: jenkins
         Containers:
           Jnlp:
-            Image: jenkinsci/jnlp-slave:3.26-1
+            Image: jenkinsci/jnlp-slave:3.26-1-alpine
+
             RequestCpu: "100m"
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'


### PR DESCRIPTION
This change should be merged after https://github.com/jenkins-x/jenkins-x-image/pull/41 and should use 
the updated version of jenkinsx image. 

Fixes #4208