### PR TITLE
chore: improve devpod ports

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -988,7 +988,7 @@ jenkins:
         Name: nodejs
         # ServiceAccount: fooo
         Label: jenkins-nodejs
-        DevPodPorts: 9229, 3000
+        DevPodPorts: 9229, 3000, 8080
         volumes:
         - type: Secret
           secretName: jenkins-docker-cfg
@@ -1025,7 +1025,7 @@ jenkins:
         Name: serverless
         # ServiceAccount: fooo
         Label: jenkins-serverless
-        DevPodPorts: 9229, 3000
+        DevPodPorts: 9229, 3000, 8080
         volumes:
         - type: Secret
           secretName: jenkins-docker-cfg


### PR DESCRIPTION
lets add port 8080 to node/js devpods as thats the default for apps via `npm start`