### PR TITLE
Give users permissions for other api groups than core and jenkins.io

### DIFF
--- a/templates/committer-role.yaml
+++ b/templates/committer-role.yaml
@@ -11,6 +11,7 @@ metadata:
 rules:
   - apiGroups:
     - jenkins.io
+    - rbac.authorization.k8s.io
     resources:
     - "*"
     verbs:
@@ -19,6 +20,9 @@ rules:
     - watch
   - apiGroups:
     - ""
+    - extensions
+    - apps
+    - batch
     resources:
     - "*"
     verbs:

--- a/templates/owner-role.yaml
+++ b/templates/owner-role.yaml
@@ -10,19 +10,12 @@ metadata:
      description: "A team owner can add/remove users and has write access to all team resources"
 rules:
   - apiGroups:
-    - jenkins.io
-    resources:
-    - "*"
-    verbs:
-    - list
-    - get
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-  - apiGroups:
     - ""
+    - extensions
+    - apps
+    - rbac.authorization.k8s.io
+    - batch
+    - jenkins.io
     resources:
     - "*"
     verbs:

--- a/templates/viewer-role.yaml
+++ b/templates/viewer-role.yaml
@@ -10,15 +10,12 @@ metadata:
      description: "A viewer can view all project resources"
 rules:
   - apiGroups:
-    - jenkins.io
-    resources:
-    - "*"
-    verbs:
-    - list
-    - get
-    - watch
-  - apiGroups:
     - ""
+    - jenkins.io
+    - extensions
+    - apps
+    - rbac.authorization.k8s.io
+    - batch
     resources:
     - "*"
     verbs:


### PR DESCRIPTION
Especially `jx get applications` doesn't work for a non admin with the previous role definitions
Other than solving that I have tried to add api groups that it seems a reasonable a user might need
to add resources from.
When all api groups have the same permissions I have removed the superfluous one.