### PR TITLE
fix: Give service account for role controller enough permissions

### DIFF
--- a/templates/committer-role.yaml
+++ b/templates/committer-role.yaml
@@ -25,6 +25,7 @@ rules:
     - batch
     resources:
     - "*"
+    - "pods/*"
     verbs:
     - list
     - get

--- a/templates/owner-role.yaml
+++ b/templates/owner-role.yaml
@@ -18,6 +18,7 @@ rules:
     - jenkins.io
     resources:
     - "*"
+    - "pods/*"
     verbs:
     - list
     - get

--- a/values.yaml
+++ b/values.yaml
@@ -334,11 +334,22 @@ controllerrole:
     rules:
     - apiGroups:
       - ""
+      - extensions
+      - apps
+      - rbac.authorization.k8s.io
+      - batch
+      - jenkins.io
       resources:
-      - namespaces
+      - "*"
+      - "pods/*"
       verbs:
-      - get
       - list
+      - get
+      - watch
+      - create
+      - update
+      - patch
+      - delete
     - apiGroups:
       - apiextensions.k8s.io
       resources:
@@ -348,31 +359,9 @@ controllerrole:
       - create
       - update
       - list
-    - apiGroups:
-      - jenkins.io
-      resources:
-      - environments
-      - teams
-      - users
-      verbs:
-      - list
-      - get
-      - watch
   role:
     enabled: true
     rules:
-    - apiGroups:
-      - rbac.authorization.k8s.io
-      resources:
-      - roles
-      - rolebindings
-      verbs:
-      - list
-      - get
-      - watch
-      - create
-      - update
-      - delete
     - apiGroups:
       - jenkins.io
       resources:
@@ -383,15 +372,6 @@ controllerrole:
       - watch
       - create
       - update
-    - apiGroups:
-      - ""
-      resources:
-      - roles
-      - rolebindings
-      verbs:
-      - list
-      - watch
-      - get
 
 controllerteam:
   enabled: true


### PR DESCRIPTION
The service account controller role is running as needs both permissions to change permissisons in
all the teams namespaces, so in practice it needs to be in the ClusterRole. Also it needs all the
permissions it is assigning to others itself.

While at it I give the committer and owner roles pod permissions (most importantly exec).