### PR TITLE
Added in annotation option in cm for pod templates

### DIFF
--- a/templates/jenkins-x-pod-templates.yaml
+++ b/templates/jenkins-x-pod-templates.yaml
@@ -16,6 +16,11 @@ data:
         jenkins.io/kind: build-pod
       annotations:
         jenkins-x.io/devpodPorts: {{ $pval.DevPodPorts }}
+      {{- if $pval.annotations }}
+      {{- range $key, $value := $pval.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
 {{- if $pval.ServiceAccount }}
       serviceAccount: {{ $pval.ServiceAccount }}

--- a/values.yaml
+++ b/values.yaml
@@ -390,7 +390,7 @@ controllercommitstatus:
       - watch
       - list
       - get
-      
+
 controllerrole:
   enabled: true
   serviceaccount:
@@ -843,6 +843,8 @@ jenkins:
         Name: maven
         Label: jenkins-maven
         DevPodPorts: 5005, 8080
+        # annotations:
+        #   iam.amazonaws.com/role: arn:aws:iam::accountid:role/rolename
         volumes:
         - type: Secret
           secretName: jenkins-maven-settings
@@ -1554,7 +1556,7 @@ jenkins:
             # AlwaysPullImage: true
             Command: "/bin/sh -c"
             Args: "cat"
-            Tty: true            
+            Tty: true
       Ruby:
         Name: ruby
         # ServiceAccount: fooo


### PR DESCRIPTION
first commit on getting annotation options in for pod templates to address issue #4513.

Work in progress - Ive got it to work properly and update the jenkins-x-pod-templates config map properly, but I cannot find where this config map gets pushed into the config for jenkins. Missing a piece of the puzzle.