### PR TITLE
Create BuildPacks through Helm Chart

### DIFF
--- a/templates/buildpacks.yaml
+++ b/templates/buildpacks.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.BuildPacks }}
+apiVersion: v1
+kind: List
+items:
+{{- range $pkey, $pval := .Values.BuildPacks }}
+- apiVersion: jenkins.io/v1
+  kind: BuildPack
+  metadata:
+    name: {{ quote $pkey }}
+  spec:
+    label: {{ quote $pval.Label }}
+    gitUrl: {{ quote $pval.GitUrl }}
+    gitRef: {{ quote $pval.GitRef }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,16 @@ teamRoles:
   team-admin:
     enabled: true
 
+BuildPacks:
+  "classic-workloads":
+     Label: "Library Workloads: CI+Release but no CD"
+     GitUrl: "https://github.com/jenkins-x-buildpacks/jenkins-x-classic.git"
+     GitRef: "master"
+  "kubernetes-workloads":
+     Label: "Kubernetes Workloads: Automated CI+CD with GitOps Promotion"
+     GitUrl: "https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes.git"
+     GitRef: "master"
+
 gcpreviews:
   serviceaccount:
     enabled: true


### PR DESCRIPTION
Currently, we cannot create buildpack resources through the helm chart. This will allow such feature. 

By default, it creates the buildpacks hard-coded in the JX repository. This can be used as a reference for when other users want to use a different location for their buildpacks.

Users can then append to / overwrite the default buildpacks through an override myvalues.yaml
```
BuildPacks:
  "short-name-workloads":
    Label: "Long name that you see by calling `jx edit buildpacks`
    GitUrl: "https://abc.xyz/path/to/buildpacks.git"
    GitRef: "master"
```