### PR TITLE
controllerworkflow is missing permissions

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -271,6 +271,7 @@ controllerworkflow:
       - jenkins.io
       resources:
       - workflows
+      - environments
       verbs:
       - list
       - get
@@ -279,6 +280,7 @@ controllerworkflow:
       - ""
       resources:
       - services
+      - secrets
       verbs:
       - list
       - get


### PR DESCRIPTION
```
WARNING: The current user cannot query secrets in the namespace jx: secrets is forbidden: User "system:serviceaccount:jx:jenkins-x-controllerworkflow" cannot list secrets in the namespace "jx"
Failed to find environment staging: environments.jenkins.io "staging" is forbidden: User "system:serviceaccount:jx:jenkins-x-controllerworkflow" cannot get environments.jenkins.io in the namespace "jx"
```