### PR TITLE
gcpreviews should run with the jenkins serviceaccount

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@ teamRoles:
 
 gcpreviews:
   serviceaccount:
-    enabled: true
+    customName: jenkins
   cronjob:
     enabled: true
     schedule: "0 */3 * * *"
@@ -17,57 +17,6 @@ gcpreviews:
   - "gc"
   - "previews"
   - "--batch-mode"
-  role:
-    enabled: true
-    rules:
-    - apiGroups:
-      - jenkins.io
-      resources:
-      - plugins
-      verbs:
-      - get
-      - list
-      - watch
-    - apiGroups:
-      - jenkins.io
-      resources:
-      - environments
-      verbs:
-      - list
-      - delete
-    - apiGroups:
-      - ""
-      resources:
-      - secrets
-      verbs:
-      - get
-      - list
-    - apiGroups:
-      - apiextensions.k8s.io
-      resources:
-      - customresourcedefinitions
-      verbs:
-      - create
-
-  clusterrole:
-    enabled: true
-    rules:
-    - apiGroups:
-      - apiextensions.k8s.io
-      resources:
-      - customresourcedefinitions
-      verbs:
-      - get
-      - create
-      - update
-    - apiGroups:
-      - ""
-      resources:
-      - namespaces
-      verbs:
-      - get
-      - delete
-      - list
 
 gcactivities:
   serviceaccount:


### PR DESCRIPTION
This is the second part of the "delete the helm release when deleting the preview environment" fix, and depends on the jx PR https://github.com/jenkins-x/jx/pull/2668

If the team setting is to use a local tiller, then the gcpreview job will need to have sufficient rights to create/delete resources.
To handle this, I added a new feature in the jx chart: setting a custom service account name. This allows to run a pod with an existing service account, without creating a new one.

This PR setup the gcpreviews with the jenkins service account - which is cluster-admin, so that it get enough rights to run a local tiller, when deleting helm charts used by preview environments