### PR TITLE
fix: use a docker image with jx + helm + kubectl for gc previews

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,9 @@ gcpreviews:
   - "gc"
   - "previews"
   - "--batch-mode"
+  image:
+    repository: jenkinsxio/builder-go
+    tag: 0.1.199
 
 gcactivities:
   serviceaccount:


### PR DESCRIPTION
fixes https://github.com/jenkins-x/jx/issues/2723