### PR TITLE
chore: lets use maven as the container name for all java versions

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -866,7 +866,7 @@ jenkins:
             Args: "cat"
             Tty: true
       Maven-Java11:
-        Name: maven-java11
+        Name: maven
         Label: jenkins-maven-java11
         DevPodPorts: 5005, 8080
         volumes:


### PR DESCRIPTION
which simplifies the Jenkinsfiles and the changes to them if folks want to use different java versions