### PR TITLE
fix: for ~/.m2/settings.xml the server.id must align with mirror.id

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1782,7 +1782,7 @@ PipelineSecrets:
         </mirrors>
         <servers>
             <server>
-            <id>local-nexus</id>
+            <id>nexus</id>
             <username>admin</username>
             <password>admin123</password>
         </server>
@@ -1796,9 +1796,9 @@ PipelineSecrets:
             <profile>
                 <id>nexus</id>
                 <properties>
-                    <altDeploymentRepository>local-nexus::default::http://nexus/repository/maven-snapshots/</altDeploymentRepository>
-                    <altReleaseDeploymentRepository>local-nexus::default::http://nexus/repository/maven-releases/</altReleaseDeploymentRepository>
-                    <altSnapshotDeploymentRepository>local-nexus::default::http://nexus/repository/maven-snapshots/</altSnapshotDeploymentRepository>
+                    <altDeploymentRepository>nexus::default::http://nexus/repository/maven-snapshots/</altDeploymentRepository>
+                    <altReleaseDeploymentRepository>nexus::default::http://nexus/repository/maven-releases/</altReleaseDeploymentRepository>
+                    <altSnapshotDeploymentRepository>nexus::default::http://nexus/repository/maven-snapshots/</altSnapshotDeploymentRepository>
                 </properties>
             </profile>
             <profile>


### PR DESCRIPTION
#8 by @rawlingsj was wrong from the start, but with anonymous access enabled, no one noticed. As of https://github.com/jenkins-x/nexus/pull/26 by @garethjevans, this broke access to Nexus for anyone running Maven-based projects who recently ran `jx upgrade platform`, as noted recently in https://github.com/jenkins-x/jx/issues/2052#issuecomment-458466586.

Fix verified locally by means of `kubectl edit secret jenkins-maven-settings`.