### PR TITLE
Dummy annotation into kaniko-secret as workaround.

### DIFF
--- a/templates/kaniko-secret.yaml
+++ b/templates/kaniko-secret.yaml
@@ -4,6 +4,9 @@ data:
   kaniko-secret: {{ .Values.KanikoSecret.Data | b64enc | quote }}
 kind: Secret
 metadata:
+  annotations:
+    # Workaround until Kubernetes Credentials Provider can deal with a secret without annotations.
+    jenkins.io/foo: bar
   labels:
     jenkins.io/credentials-type: secretText
   name: kaniko-secret


### PR DESCRIPTION
Workaround until Kubernetes Credentials Provider can deal with a secret without annotations.