### PR TITLE
fix: do not set TILLER_NAMESPACE to an empty string

### DIFF
--- a/templates/jenkins-x-pod-templates.yaml
+++ b/templates/jenkins-x-pod-templates.yaml
@@ -75,8 +75,10 @@ data:
             configMapKeyRef:
               name: jenkins-x-docker-registry
               key: docker.registry
+  {{- if $globalenv.TILLER_NAMESPACE }}
         - name: TILLER_NAMESPACE
           value: {{ $globalenv.TILLER_NAMESPACE }}
+  {{- end }}
   {{- range $ekey, $eval := $pval.EnvVars }}
         - name: {{ $ekey }}
           value: {{ $eval }}


### PR DESCRIPTION
fixes https://github.com/jenkins-x/jx/issues/1998

_For some reason_, Helm cannot find Tiller when the `TILLER_NAMESPACE` environment variable is set to an empty string.

Note to JX devs: I didn't test this!  This was just a "best guess"