### PR TITLE
fix: duplicate Maven-Java11 pod template name

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -981,7 +981,7 @@ jenkins:
             Args: "cat"
             Tty: true
       Maven-Java11:
-        Name: maven
+        Name: maven-java11
         Label: jenkins-maven-java11
         DevPodPorts: 5005, 8080
         volumes:


### PR DESCRIPTION
This PR fixes Jenkins Pod template name for Maven-Java11 to use `maven-java11` in order to avoid the same pod name conflict created by Maven pod template.