### PR TITLE
Fix indentation to create clusterrole for gcpreviews

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -50,27 +50,27 @@ gcpreviews:
           - list
           - get
           - watch
-    clusterrole:
-      enabled: true
-      rules:
-        - apiGroups:
-            - ""
-          resources:
-            - namespaces
-          verbs:
-            - get
-            - list
-            - delete
-        - apiGroups:
-            - ""
-          resources:
-            - pods
-            - pods/portforward
-          verbs:
-            - get
-            - delete
-            - list
-            - create
+  clusterrole:
+    enabled: true
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs:
+          - get
+          - list
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+          - pods/portforward
+        verbs:
+          - get
+          - delete
+          - list
+          - create
 
 gcactivities:
   serviceaccount:


### PR DESCRIPTION
Fixing https://github.com/jenkins-x/jx/issues/3430
Follow up of https://github.com/jenkins-x/jenkins-x-platform/pull/5012

There was an indentation issue that I missed during my testing and that prevents the clusterrole to be created.

Sorry for that.