### PR TITLE
Don't run Privileged until really needed

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -915,7 +915,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           aws-cdk:
             Image: gcr.io/jenkinsxio/builder-maven-nodejs:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -970,7 +970,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Maven:
             Image: gcr.io/jenkinsxio/builder-maven:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "1"
@@ -1026,7 +1026,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Maven:
             Image: gcr.io/jenkinsxio/builder-maven-java11:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "1"
@@ -1076,7 +1076,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Gradle:
             Image: gcr.io/jenkinsxio/builder-gradle:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "1"
@@ -1129,7 +1129,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Scala:
             Image: gcr.io/jenkinsxio/builder-scala:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "1"
@@ -1175,7 +1175,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Go:
             Image: gcr.io/jenkinsxio/builder-go:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "600Mi"
             LimitCpu: "1"
@@ -1220,7 +1220,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Terraform:
             Image: gcr.io/jenkinsxio/builder-terraform:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "600Mi"
             LimitCpu: "1"
@@ -1266,7 +1266,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Rust:
             Image: gcr.io/jenkinsxio/builder-rust:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "1"
@@ -1312,7 +1312,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Newman:
             Image: gcr.io/jenkinsxio/builder-newman:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "1"
@@ -1359,7 +1359,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Nodejs:
             Image: gcr.io/jenkinsxio/builder-nodejs:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -1402,7 +1402,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           MavenNodejs:
             Image: gcr.io/jenkinsxio/builder-maven-nodejs:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -1445,7 +1445,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           JX-base:
             Image: gcr.io/jenkinsxio/builder-jx:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "200m"
             RequestMemory: "256Mi"
             LimitCpu: "400m"
@@ -1490,7 +1490,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Promote:
             Image: gcr.io/jenkinsxio/builder-jx:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "200m"
             RequestMemory: "100Mi"
             LimitCpu: "400m"
@@ -1537,7 +1537,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Python:
             Image: gcr.io/jenkinsxio/builder-python2:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -1584,7 +1584,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Python:
             Image: gcr.io/jenkinsxio/builder-python:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -1631,7 +1631,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Python:
             Image: gcr.io/jenkinsxio/builder-python37:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -1678,7 +1678,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Ruby:
             Image: gcr.io/jenkinsxio/builder-ruby:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -1725,7 +1725,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Swift:
             Image: gcr.io/jenkinsxio/builder-swift:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "400m"
             RequestMemory: "512Mi"
             LimitCpu: "2"
@@ -1771,7 +1771,7 @@ jenkins:
             Args: '${computer.jnlpmac} ${computer.name}'
           Dlang:
             Image: gcr.io/jenkinsxio/builder-dlang:0.1.334
-            Privileged: true
+            Privileged: false
             RequestCpu: "500m"
             RequestMemory: "1024Mi"
             LimitCpu: "1"


### PR DESCRIPTION
`Privileged` is only required to run Docker-in-Docker or such hack-ish things. Using Privileged by default introduce significant security impacts. Better to not let user shoot in their own foot