### PR TITLE
Fix if-else to keep newline character

### DIFF
--- a/templates/jenkins-x-docker-registry.yaml
+++ b/templates/jenkins-x-docker-registry.yaml
@@ -5,8 +5,8 @@ metadata:
   annotations:
     expose.config.fabric8.io/clusterip-port-if-empty-key: docker.registry
 data:
-{{- if .Values.jenkins.Servers.Global.EnvVars.DOCKER_REGISTRY -}}
+{{- if .Values.jenkins.Servers.Global.EnvVars.DOCKER_REGISTRY }}
   docker.registry: {{ .Values.jenkins.Servers.Global.EnvVars.DOCKER_REGISTRY }}
-{{- else -}}
+{{- else }}
   docker.registry: {{ .Values.dockerRegistry }}
 {{- end }}


### PR DESCRIPTION
Removed trailing `-` characters from if-else in helm chart to keep newline characters in the generated yaml.
fixes https://github.com/jenkins-x/jx/issues/3494