### PR TITLE
Fix gcpreviews service account roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ install: clean setup build
 	$(HELM) upgrade --debug --install $(NAME) jenkins-x-platform
 
 apply: build
-	cd jenkins-x-platform
-	jx step helm apply $(NAME) .
+	cd jenkins-x-platform && jx step helm apply $(NAME) .
 
 upgrade: clean setup build
 	$(HELM) upgrade --debug --install $(NAME) jenkins-x-platform

--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -39,44 +39,149 @@ gcpreviews:
     enabled: true
     rules:
       - apiGroups:
-          - jenkins.io
+        - jenkins.io
         resources:
-          - environments
+        - environments
+        - releases
+        - facts
+        - pipelineactivities
+        - commitstatuses
+        - schedulers
+        - extensions
+        - users
+        - teams
+        - pipelinestructures
+        - plugins
+        - buildpacks
+        - apps
+        - sourcerepositories
+        - gitservices
+        - workflows
+        - environmentrolebindings
+        - sourcerepositorygroups
         verbs:
-          - list
-          - get
-          - patch
-          - update
-          - delete
+        - list
+        - get
+        - patch
+        - update
+        - delete
       - apiGroups:
-          - ""
+        - ""
         resources:
-          - secrets
+        - secrets
+        - services
+        - replicationcontrollers
+        - persistentvolumeclaims
+        - configmaps
+        - serviceaccounts
         verbs:
-          - list
-          - get
-          - watch
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - apps
+        resources:
+        - daemonsets
+        - deployments
+        - replicasets
+        - statefulsets
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - autoscaling
+        resources:
+        - horizontalpodautoscalers
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - batch
+        resources:
+        - jobs
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - tekton.dev
+        resources:
+        - pipelines
+        - taskruns
+        - tasks
+        - clustertasks
+        - pipelineresources
+        - pipelineruns
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
   clusterrole:
     enabled: true
     rules:
-      - apiGroups:
-          - ""
-        resources:
-          - namespaces
-        verbs:
-          - get
-          - list
-          - delete
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-          - pods/portforward
-        verbs:
-          - get
-          - delete
-          - list
-          - create
+    - apiGroups:
+      - ""
+      resources:
+      - namespaces
+      verbs:
+      - get
+      - list
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - pods/portforward
+      verbs:
+      - get
+      - create
+      - list
+      - delete
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resources:
+      - clusterroles
+      - clusterrolebindings
+      - customresourcedefinitions
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - create
+    - apiGroups:
+      - tekton.dev
+      resources:
+      - clustertasks
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
 
 gcactivities:
   serviceaccount:


### PR DESCRIPTION
Fixing issue: https://github.com/jenkins-x/jx/issues/3430

gcpreviews service account was missing some roles in order to cleanup the preview envs.

Not sure this solution is ideal, it will depend on the possibility for preview env to create different kind of resources depending on application specificities.
I don't want to give full admin access to this service account though so I'm happy to have some feedback on that.