### PR TITLE
chore(deps): bump jenkins-x/jenkins-x-builders from 0.1.560 to 0.1.564

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) |  | [0.1.564]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jenkins-x
+  repo: jenkins-x-builders
+  url: https://github.com/jenkins-x/jenkins-x-builders
+  version: 0.1.564
+  versionURL: ""

--- a/jenkins-x-platform/cleanup/values.yaml
+++ b/jenkins-x-platform/cleanup/values.yaml
@@ -1,2 +1,3 @@
 Image: "fabric8/exposecontroller"
 ImageTag: "2.3.34"
+

--- a/jenkins-x-platform/pipelinecontroller/values.yaml
+++ b/jenkins-x-platform/pipelinecontroller/values.yaml
@@ -1,3 +1,4 @@
 pipelinecontroller:
   Image: rawlingsj/pipeline-controller
   ImageTag: dev
+

--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -1880,7 +1880,7 @@ jenkins:
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
           Ruby:
-            Image: gcr.io/jenkinsxio/builder-ruby:0.1.560
+Image: gcr.io/jenkinsxio/builder-ruby:0.1.564
             Privileged: true
             RequestCpu: "400m"
             RequestMemory: "512Mi"
@@ -2258,3 +2258,4 @@ grafana:
       annotations:
         fabric8.io/expose: "true"
         fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
+


### PR DESCRIPTION
Update [jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) from [0.1.560](https://github.com/jenkins-x/jenkins-x-builders/releases/tag/0.1.560) to 0.1.564

Command run was `/Users/pmuir/go/src/github.com/jenkins-x/jx/build/jx step create pr chart --name gcr.io/jenkinsxio/builder-ruby --version 0.1.564 --repo https://github.com/jenkins-x/jenkins-x-platform.git`