### PR TITLE
chore(deps): bump jenkins-x/jenkins-x-builders from 0.1.564 to 1.2.3

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) |  | [0.1.564]() | 
+[jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) |  | [1.2.3]() | 
 [jenkins-x/jx](https://github.com/jenkins-x/jx) |  | [2.0.452](https://github.com/jenkins-x/jx/releases/tag/v2.0.452) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,7 +3,7 @@ dependencies:
   owner: jenkins-x
   repo: jenkins-x-builders
   url: https://github.com/jenkins-x/jenkins-x-builders
-  version: 0.1.564
+  version: 1.2.3
   versionURL: ""
 - host: github.com
   owner: jenkins-x

--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -933,7 +933,7 @@ jenkins:
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
           aws-cdk:
-            Image: gcr.io/jenkinsxio/builder-maven-nodejs:0.1.564
+            Image: gcr.io/jenkinsxio/builder-maven-nodejs:1.2.3
             Privileged: true
             RequestCpu: "400m"
             RequestMemory: "512Mi"
@@ -1570,7 +1570,7 @@ jenkins:
             RequestMemory: "128Mi"
             Args: '${computer.jnlpmac} ${computer.name}'
           MavenNodejs:
-            Image: gcr.io/jenkinsxio/builder-maven-nodejs:0.1.564
+            Image: gcr.io/jenkinsxio/builder-maven-nodejs:1.2.3
             Privileged: true
             RequestCpu: "400m"
             RequestMemory: "512Mi"


### PR DESCRIPTION
Update [jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) from 0.1.564 to 1.2.3

Command run was `jx step create pr chart --name gcr.io/jenkinsxio/builder-maven-nodejs --version 1.2.3 --repo https://github.com/jenkins-x/jenkins-x-platform.git`