### PR TITLE
fix: add ingress permission for GC previews

### DIFF
--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -134,6 +134,13 @@ gcpreviews:
         verbs:
         - list
         - get
+      - apiGroups:
+        - extensions
+        resources:
+        - ingresses
+        verbs:
+        - list
+        - get
   clusterrole:
     enabled: true
     rules:


### PR DESCRIPTION
In order to find the vault service the GC preview jobs needs permission to list and get the ingresses

Signed-off-by: warrenbailey <warren@warrenbailey.net>