### PR TITLE
fix: controllerworkflow should use the gcr image, not docker.io

### DIFF
--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -389,6 +389,9 @@ controllerworkflow:
   args:
   - "controller"
   - "workflow"
+  image:
+    repository: gcr.io/jenkinsxio/builder-jx
+    tag: 0.1.654
   clusterrole:
     enabled: true
     rules:


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>