### PR TITLE
feat: let controllerbuild access configmaps

### DIFF
--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -536,6 +536,7 @@ controllerbuild:
       - pods
       - pods/log
       - secrets
+      - configmaps
       verbs:
       - get
       - list


### PR DESCRIPTION
We need controllerbuild to access ConfigMaps so it can obtain the `requirements.yaml` values  from either `jx-install-config` or the new `jx-requirements-config` so it can obtain install values.