### PR TITLE
feat: add tekton read privileges so controllerrole can create rolebindings with those permissions

### DIFF
--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -680,6 +680,14 @@ controllerrole:
       - create
       - patch
       - update
+    - apiGroups:
+      - tekton.dev
+      resources:
+      - '*'
+      verbs:
+      - list
+      - get
+      - watch
 
 controllerteam:
   enabled: true


### PR DESCRIPTION
We are seeing an error in `controllerrole` when installing the UI App as it's using an `Environmentrolebinding`. 

When `controllerrole` attempts to create a `RoleBinding` for the UI, it fails because it doesn't have READ privileges on `tekton.dev` so it can't create a `RoleBinding` that has them.