### PR TITLE
feat: remove configmap permissions from ControllerBuild

### DIFF
--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -536,7 +536,6 @@ controllerbuild:
       - pods
       - pods/log
       - secrets
-      - configmaps
       verbs:
       - get
       - list


### PR DESCRIPTION
Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>

Removing the `ConfigMap` permissions from `ControllerBuild` because we are moving the data to the `Dev` `Environment` CRD and this is causing issues.