### PR TITLE
fix: Revert nexus chart to 0.1.7

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -9,4 +9,4 @@ Dependency | Sources | Version | Mismatched versions
 [jenkins-x/jx](https://github.com/jenkins-x/jx.git) | [github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) | [2.0.1102](https://github.com/jenkins-x/jx/releases/tag/v2.0.1102) | **2.0.564**: [github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders)
 [jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml) |  | [0.1.1029]() | 
 [jenkins-x/jenkins-x-image](https://github.com/jenkins-x/jenkins-x-image) |  | [0.0.81](https://github.com/jenkins-x/jenkins-x-image/releases/tag/v0.0.81) | 
-[jenkins-x-charts/nexus](https://github.com/jenkins-x-charts/nexus) |  | [0.1.18]() | 
+[jenkins-x-charts/nexus](https://github.com/jenkins-x-charts/nexus) |  | [0.1.7]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -55,5 +55,5 @@ dependencies:
   owner: jenkins-x-charts
   repo: nexus
   url: https://github.com/jenkins-x-charts/nexus
-  version: 0.1.18
+  version: 0.1.7
   versionURL: ""

--- a/jenkins-x-platform/requirements.yaml
+++ b/jenkins-x-platform/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
 - condition: nexus.enabled
   name: nexus
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.1.18
+  version: 0.1.7
 - name: heapster
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.3.2


### PR DESCRIPTION
0.1.18 is failing with `PostStartHookError: command '/opt/sonatype/nexus/postStart.sh' exited with 1: ERROR: Login to nexus failed. Tried both the default password and the provided password secret file.`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>