### PR TITLE
fix: controllerbuild needs to be able to get git credentials

### DIFF
--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -546,10 +546,26 @@ controllerbuild:
       - pods
       - pods/log
       - secrets
+      - configmaps
+      - serviceaccounts
       verbs:
       - get
       - list
       - watch
+    - apiGroups:
+      - extensions
+      resources:
+      - ingresses
+      verbs:
+      - list
+      - get
+    - apiGroups:
+      - vault.banzaicloud.com
+      resources:
+      - vaults
+      verbs:
+      - list
+      - get
 
 controllercommitstatus:
   enabled: false


### PR DESCRIPTION
When there's a `jx-auth-config` configmap present, we end up needing a
_lot_ more permissions to run `jx step git credentials`. I _think_
this is right, but I may be drastically overshooting, so I want to
make sure @ccojocar in particular reviews this.

fixes https://github.com/jenkins-x/jx/issues/6568

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>