### PR TITLE
fix: Revert nexus back to last version before upgrade problems

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -9,4 +9,4 @@ Dependency | Sources | Version | Mismatched versions
 [jenkins-x/jx](https://github.com/jenkins-x/jx.git) | [github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) | [2.1.12](https://github.com/jenkins-x/jx/releases/tag/v2.1.12) | **2.0.564**: [github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders)
 [jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml) |  | [0.1.1210]() | 
 [jenkins-x/jenkins-x-image](https://github.com/jenkins-x/jenkins-x-image) |  | [0.0.81](https://github.com/jenkins-x/jenkins-x-image/releases/tag/v0.0.81) | 
-[jenkins-x-charts/nexus](https://github.com/jenkins-x-charts/nexus) |  | [0.1.27]() | 
+[jenkins-x-charts/nexus](https://github.com/jenkins-x-charts/nexus) |  | [0.1.21]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -55,5 +55,5 @@ dependencies:
   owner: jenkins-x-charts
   repo: nexus
   url: https://github.com/jenkins-x-charts/nexus
-  version: 0.1.27
+  version: 0.1.21
   versionURL: ""

--- a/jenkins-x-platform/requirements.yaml
+++ b/jenkins-x-platform/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
 - condition: nexus.enabled
   name: nexus
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.1.27
+  version: 0.1.21
 - condition: heapster.enabled
   name: heapster
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
`jx upgrade boot` gets stuck trying to upgrade Nexus due to Nexus being a `Deployment` that tries to use the same PVC in both the old version and the new version and not being able to. So let's revert back for the moment to the version from before we started trying to deal with upgrading Nexus itself until we get that straightened up.

Short-term workaround for https://github.com/jenkins-x/jx/issues/7115

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>