### PR TITLE
fix: add extra permissions to the controllerbuild and give "namespace admin" to controllerrole

### DIFF
--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -571,6 +571,26 @@ controllerbuild:
       verbs:
       - list
       - get
+    - apiGroups:
+      - tekton.dev
+      resources:
+      - pipelines
+      - pipelinereources
+      - pipelineruns
+      - tasks
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - get
+      - list
+      - watch
+
 
 controllercommitstatus:
   enabled: false
@@ -701,31 +721,11 @@ controllerrole:
     enabled: true
     rules:
     - apiGroups:
-      - jenkins.io
+      - "*"
       resources:
-      - environmentrolebindings
+      - "*"
       verbs:
-      - list
-      - get
-      - watch
-      - create
-      - patch
-      - update
-    - apiGroups:
-      - ""
-      resources:
-      - namespaces
-      verbs:
-      - list
-      - get
-    - apiGroups:
-      - tekton.dev
-      resources:
-      - '*'
-      verbs:
-      - list
-      - get
-      - watch
+      - "*"
 
 controllerteam:
   enabled: false
@@ -2572,7 +2572,3 @@ grafana:
       annotations:
         fabric8.io/expose: "true"
         fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
-
-
-
-


### PR DESCRIPTION
Give the `controllerbuild` role extra permissions to match the `clusterrole` ones.

Also give the `controllerrole` role a "namespace admin" rights so it can be deployed on other namespaces and let the `controllerrole` controller work without cluster wide permissions.