### PR TITLE
refactor: bump up docker registry chart version

### DIFF
--- a/jenkins-x-platform/requirements.yaml
+++ b/jenkins-x-platform/requirements.yaml
@@ -28,7 +28,7 @@ dependencies:
 - condition: docker-registry.enabled
   name: docker-registry
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.5.0
+  version: 1.8.3
 - alias: gcactivities
   name: jx
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Change the version of the helm chart for docker-registry to 1.8.3 to remove the usage of deprecated apis. https://github.com/helm/charts/pull/17454/files