### PR TITLE
feat: allow the team roles rules to be overridden

### DIFF
--- a/jenkins-x-platform/templates/committer-role.yaml
+++ b/jenkins-x-platform/templates/committer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.teamRoles.viewer.enabled -}}
+{{- if .Values.teamRoles.committer.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -8,32 +8,8 @@ metadata:
   annotations:
     title: "Committer"
     description: "A committer can write to project resources but cannot add/remove users"
+{{ if .Values.teamRoles.committer.rules -}}
 rules:
-  - apiGroups:
-    - jenkins.io
-    - rbac.authorization.k8s.io
-    - tekton.dev
-    resources:
-    - "*"
-    verbs:
-    - list
-    - get
-    - watch
-  - apiGroups:
-    - ""
-    - extensions
-    - apps
-    - batch
-    resources:
-    - "*"
-    - "pods/*"
-    - deployments
-    verbs:
-    - list
-    - get
-    - watch
-    - create
-    - update
-    - patch
-    - delete
+{{ toYaml .Values.teamRoles.committer.rules | indent 0 }}
+{{- end }}
 {{- end }}

--- a/jenkins-x-platform/templates/owner-role.yaml
+++ b/jenkins-x-platform/templates/owner-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.teamRoles.viewer.enabled -}}
+{{- if .Values.teamRoles.owner.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -8,25 +8,8 @@ metadata:
   annotations:
      title: "Team Owner"
      description: "A team owner can add/remove users and has write access to all team resources"
+{{ if .Values.teamRoles.owner.rules -}}
 rules:
-  - apiGroups:
-    - ""
-    - extensions
-    - apps
-    - rbac.authorization.k8s.io
-    - batch
-    - jenkins.io
-    - tekton.dev
-    resources:
-    - "*"
-    - "pods/*"
-    - deployments
-    verbs:
-    - list
-    - get
-    - watch
-    - create
-    - update
-    - patch
-    - delete
+{{ toYaml .Values.teamRoles.owner.rules | indent 0 }}
+{{- end }}
 {{- end }}

--- a/jenkins-x-platform/templates/viewer-role.yaml
+++ b/jenkins-x-platform/templates/viewer-role.yaml
@@ -8,21 +8,8 @@ metadata:
   annotations:
      title: "Viewer"
      description: "A viewer can view all project resources"
+{{ if .Values.teamRoles.viewer.rules -}}
 rules:
-  - apiGroups:
-    - ""
-    - jenkins.io
-    - extensions
-    - apps
-    - rbac.authorization.k8s.io
-    - batch
-    - tekton.dev
-    resources:
-    - "*"
-    - pipelineruns
-    - deployments
-    verbs:
-    - list
-    - get
-    - watch
+{{ toYaml .Values.teamRoles.viewer.rules | indent 0 }}
+{{- end }}
 {{- end }}

--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -8,6 +8,76 @@ extensions:
 teamRoles:
   viewer:
     enabled: true
+    rules:
+      - apiGroups:
+        - ""
+        - jenkins.io
+        - extensions
+        - apps
+        - rbac.authorization.k8s.io
+        - batch
+        - tekton.dev
+        resources:
+        - "*"
+        - pipelineruns
+        - deployments
+        verbs:
+        - list
+        - get
+        - watch
+  committer:
+    enabled: true
+    rules:
+      - apiGroups:
+        - jenkins.io
+        - rbac.authorization.k8s.io
+        - tekton.dev
+        resources:
+        - "*"
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - ""
+        - extensions
+        - apps
+        - batch
+        resources:
+        - "*"
+        - "pods/*"
+        - deployments
+        verbs:
+        - list
+        - get
+        - watch
+        - create
+        - update
+        - patch
+        - delete
+  owner:
+    enabled: true
+    rules:
+      - apiGroups:
+        - ""
+        - extensions
+        - apps
+        - rbac.authorization.k8s.io
+        - batch
+        - jenkins.io
+        - tekton.dev
+        resources:
+        - "*"
+        - "pods/*"
+        - deployments
+        verbs:
+        - list
+        - get
+        - watch
+        - create
+        - update
+        - patch
+        - delete
   team-admin:
     enabled: true
 


### PR DESCRIPTION
The roles created when provisioning a Jenkins X Cluster are static - it would be useful to allow the administrator to override the rules for each role based on their needs.