### PR TITLE
fix: Upstream chartmuseum can't be upgraded to from our variant

### DIFF
--- a/jenkins-x-platform/requirements.yaml
+++ b/jenkins-x-platform/requirements.yaml
@@ -15,8 +15,8 @@ dependencies:
   version: 2.3.111
 - condition: chartmuseum.enabled
   name: chartmuseum
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 2.12.1
+  repository: http://chartmuseum.jenkins-x.io
+  version: 1.1.7
 - condition: nexus.enabled
   name: nexus
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>